### PR TITLE
fix(pabc): wait-for-migrations gebruikt job-wr i.p.v. job

### DIFF
--- a/charts/pabc/templates/deployment.yaml
+++ b/charts/pabc/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
       - name: "{{ .Chart.Name }}-wait-for-migrations"
         image: "{{ .Values.initContainers.waitFor.image.repository }}:{{ .Values.initContainers.waitFor.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.waitFor.image.pullPolicy }}
-        args: 
-        - "job"
+        args:
+        - "job-wr"
         - "{{ include "pabc.fullname" . }}-migrations-{{ .Release.Revision }}"
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
De init-container k8s-wait-for hangt in 'job'-mode eeuwig zodra de migratie-job een failed-poging in de historie heeft (bv. Postgres onbereikbaar na drain/undrain), ook al is de job Complete met succeeded>=1. 'job-wr' negeert failed-pogingen en wacht op minstens 1 succes, zodat de pod Ready wordt na een herprobeerde migratie.

Gereproduceerd: zelfde job (succeeded:1, failed:1) -> 'job' blijft hangen, 'job-wr' is meteen ready. Na merge: tag v1.1.1 zodat de umbrella-bump iets heeft om naar te wijzen