### PR TITLE
fix(pabc): wait-for-migrations job-wr (release 1.1.1)

### DIFF
--- a/charts/pabc/templates/deployment.yaml
+++ b/charts/pabc/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
       - name: "{{ .Chart.Name }}-wait-for-migrations"
         image: "{{ .Values.initContainers.waitFor.image.repository }}:{{ .Values.initContainers.waitFor.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.waitFor.image.pullPolicy }}
-        args: 
-        - "job"
+        args:
+        - "job-wr"
         - "{{ include "pabc.fullname" . }}-migrations-{{ .Release.Revision }}"
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Cherry-pick van #144 (`fix(pabc): wait-for-migrations gebruikt job-wr i.p.v. job`) bovenop de release-lijn.

Afgetakt van tag **v1.1.0** en **alleen** commit `1bc370b` gecherry-pickt, zodat er geen ongereleasede `main`-features meelekken. Doel: patch-release **v1.1.1** vanaf `release-1.1.x`.

Wijziging: `charts/pabc/templates/deployment.yaml` wait-for init-container `job` -> `job-wr`.