### PR TITLE
Import functional roles from Keycloak

### DIFF
--- a/PABC.Server.Test/Features/ImportKeycloakRoles/ImportKeycloakRolesControllerTests.cs
+++ b/PABC.Server.Test/Features/ImportKeycloakRoles/ImportKeycloakRolesControllerTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using PABC.Data;
+using PABC.Data.Entities;
+using PABC.Server.Features.FunctionalRoles.ImportKeycloakRoles;
+using PABC.Server.Keycloak;
+using PABC.Server.Test.TestConfig;
+
+namespace PABC.Server.Test.Features.ImportKeycloakRoles
+{
+    public class ImportKeycloakRolesControllerTests(PostgresFixture fixture)
+        : IClassFixture<PostgresFixture>, IAsyncLifetime
+    {
+        private readonly PabcDbContext _dbContext = fixture.DbContext;
+        private readonly Mock<IKeycloakAdminClient> _keycloakClientMock = new();
+
+        public async Task InitializeAsync()
+        {
+            _dbContext.ChangeTracker.Clear();
+            _dbContext.FunctionalRoles.RemoveRange(_dbContext.FunctionalRoles);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        private ImportKeycloakRolesController CreateController()
+        {
+            _dbContext.ChangeTracker.Clear();
+            return new ImportKeycloakRolesController(_dbContext, _keycloakClientMock.Object);
+        }
+
+        [Fact]
+        public async Task ImportKeycloakRoles_CreatesNewRoles_WhenNoneExist()
+        {
+            // Arrange
+            var roles = new List<RoleRepresentation>
+            {
+                new() { Name = "Behandelaar" },
+                new() { Name = "Recordbeheerder" }
+            };
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(roles);
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ImportKeycloakRolesResponse>(okResult.Value);
+
+            Assert.Equal(2, response.Created.Count);
+            Assert.Contains("Behandelaar", response.Created);
+            Assert.Contains("Recordbeheerder", response.Created);
+            Assert.Empty(response.Skipped);
+            Assert.Empty(response.Stale);
+
+            // Verify persisted in database
+            _dbContext.ChangeTracker.Clear();
+            var savedRoles = _dbContext.FunctionalRoles.ToList();
+            Assert.Equal(2, savedRoles.Count);
+        }
+
+        [Fact]
+        public async Task ImportKeycloakRoles_SkipsExisting_WhenRoleAlreadyExists()
+        {
+            // Arrange
+            _dbContext.FunctionalRoles.Add(new FunctionalRole
+            {
+                Id = Guid.NewGuid(),
+                Name = "Behandelaar"
+            });
+            await _dbContext.SaveChangesAsync();
+
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<RoleRepresentation>
+                {
+                    new() { Name = "Behandelaar" },
+                    new() { Name = "Recordbeheerder" }
+                });
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ImportKeycloakRolesResponse>(okResult.Value);
+
+            Assert.Single(response.Created);
+            Assert.Contains("Recordbeheerder", response.Created);
+            Assert.Single(response.Skipped);
+            Assert.Contains("Behandelaar", response.Skipped);
+            Assert.Empty(response.Stale);
+        }
+
+        [Fact]
+        public async Task ImportKeycloakRoles_DetectsStale_WhenRoleNoLongerInKeycloak()
+        {
+            // Arrange
+            _dbContext.FunctionalRoles.Add(new FunctionalRole
+            {
+                Id = Guid.NewGuid(),
+                Name = "Verwijderd"
+            });
+            await _dbContext.SaveChangesAsync();
+
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<RoleRepresentation>
+                {
+                    new() { Name = "Behandelaar" }
+                });
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ImportKeycloakRolesResponse>(okResult.Value);
+
+            Assert.Single(response.Created);
+            Assert.Contains("Behandelaar", response.Created);
+            Assert.Empty(response.Skipped);
+            Assert.Single(response.Stale);
+            Assert.Contains("Verwijderd", response.Stale);
+        }
+
+        [Fact]
+        public async Task ImportKeycloakRoles_ReturnsEmpty_WhenNoRolesInKeycloak()
+        {
+            // Arrange
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<RoleRepresentation>());
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ImportKeycloakRolesResponse>(okResult.Value);
+
+            Assert.Empty(response.Created);
+            Assert.Empty(response.Skipped);
+            Assert.Empty(response.Stale);
+        }
+
+        [Fact]
+        public async Task ImportKeycloakRoles_Returns500_WhenKeycloakClientThrows()
+        {
+            // Arrange
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var statusResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(500, statusResult.StatusCode);
+            var problem = Assert.IsType<ProblemDetails>(statusResult.Value);
+            Assert.Contains("Connection refused", problem.Detail);
+        }
+    }
+}

--- a/PABC.Server.Test/Features/ImportKeycloakRoles/ImportKeycloakRolesControllerTests.cs
+++ b/PABC.Server.Test/Features/ImportKeycloakRoles/ImportKeycloakRolesControllerTests.cs
@@ -93,6 +93,38 @@ namespace PABC.Server.Test.Features.ImportKeycloakRoles
         }
 
         [Fact]
+        public async Task ImportKeycloakRoles_SkipsCaseInsensitiveDuplicate_WhenRoleExistsWithDifferentCasing()
+        {
+            // Arrange — "Behandelaar" exists in PABC, Keycloak returns "behandelaar" (different casing)
+            _dbContext.FunctionalRoles.Add(new FunctionalRole
+            {
+                Id = Guid.NewGuid(),
+                Name = "Behandelaar"
+            });
+            await _dbContext.SaveChangesAsync();
+
+            _keycloakClientMock.Setup(c => c.GetRealmRoles(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<RoleRepresentation>
+                {
+                    new() { Name = "behandelaar" },
+                    new() { Name = "Recordbeheerder" }
+                });
+
+            // Act
+            var result = await CreateController().ImportKeycloakRoles();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ImportKeycloakRolesResponse>(okResult.Value);
+
+            Assert.Single(response.Created);
+            Assert.Contains("Recordbeheerder", response.Created);
+            Assert.Single(response.Skipped);
+            Assert.Contains("behandelaar", response.Skipped);
+            Assert.Empty(response.Stale);
+        }
+
+        [Fact]
         public async Task ImportKeycloakRoles_DetectsStale_WhenRoleNoLongerInKeycloak()
         {
             // Arrange

--- a/PABC.Server/Features/FunctionalRoles/ImportKeycloakRoles/ImportKeycloakRolesController.cs
+++ b/PABC.Server/Features/FunctionalRoles/ImportKeycloakRoles/ImportKeycloakRolesController.cs
@@ -26,14 +26,16 @@ namespace PABC.Server.Features.FunctionalRoles.ImportKeycloakRoles
                     .Select(r => r.Name)
                     .ToListAsync(token);
 
-                var existingSet = new HashSet<string>(existingRoles);
+                // Case-insensitive: FunctionalRole.Name has a unique index with nl_case_insensitive collation
+                var existingSet = new HashSet<string>(existingRoles, StringComparer.OrdinalIgnoreCase);
 
                 var created = new List<string>();
                 var skipped = new List<string>();
 
                 foreach (var roleName in roleNames)
                 {
-                    if (existingSet.Contains(roleName))
+                    // Add returns false if already present; also prevents duplicates within the same batch
+                    if (!existingSet.Add(roleName))
                     {
                         skipped.Add(roleName);
                         continue;
@@ -50,7 +52,7 @@ namespace PABC.Server.Features.FunctionalRoles.ImportKeycloakRoles
 
                 await db.SaveChangesAsync(token);
 
-                var keycloakSet = new HashSet<string>(roleNames);
+                var keycloakSet = new HashSet<string>(roleNames, StringComparer.OrdinalIgnoreCase);
 
                 var stale = existingSet
                     .Where(name => !keycloakSet.Contains(name))

--- a/PABC.Server/Features/FunctionalRoles/ImportKeycloakRoles/ImportKeycloakRolesController.cs
+++ b/PABC.Server/Features/FunctionalRoles/ImportKeycloakRoles/ImportKeycloakRolesController.cs
@@ -1,0 +1,83 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PABC.Data;
+using PABC.Data.Entities;
+using PABC.Server.Keycloak;
+
+namespace PABC.Server.Features.FunctionalRoles.ImportKeycloakRoles
+{
+    [ApiController]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [Route("/api/v1/functional-roles/import-keycloak")]
+    public class ImportKeycloakRolesController(PabcDbContext db, IKeycloakAdminClient keycloakClient) : Controller
+    {
+        [HttpPost]
+        [ProducesResponseType<ImportKeycloakRolesResponse>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+        [ProducesResponseType<ProblemDetails>(StatusCodes.Status500InternalServerError, MediaTypeNames.Application.ProblemJson)]
+        public async Task<IActionResult> ImportKeycloakRoles(CancellationToken token = default)
+        {
+            try
+            {
+                var realmRoles = await keycloakClient.GetRealmRoles(token);
+                var roleNames = realmRoles.Select(r => r.Name).ToList();
+
+                var existingRoles = await db.FunctionalRoles
+                    .Select(r => r.Name)
+                    .ToListAsync(token);
+
+                var existingSet = new HashSet<string>(existingRoles);
+
+                var created = new List<string>();
+                var skipped = new List<string>();
+
+                foreach (var roleName in roleNames)
+                {
+                    if (existingSet.Contains(roleName))
+                    {
+                        skipped.Add(roleName);
+                        continue;
+                    }
+
+                    db.FunctionalRoles.Add(new FunctionalRole
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = roleName
+                    });
+
+                    created.Add(roleName);
+                }
+
+                await db.SaveChangesAsync(token);
+
+                var keycloakSet = new HashSet<string>(roleNames);
+
+                var stale = existingSet
+                    .Where(name => !keycloakSet.Contains(name))
+                    .ToList();
+
+                return Ok(new ImportKeycloakRolesResponse
+                {
+                    Created = created,
+                    Skipped = skipped,
+                    Stale = stale
+                });
+            }
+            catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+            {
+                return StatusCode(500, new ProblemDetails
+                {
+                    Detail = $"Fout bij het ophalen van rollen uit Keycloak: {ex.Message}",
+                    Status = StatusCodes.Status500InternalServerError
+                });
+            }
+        }
+    }
+
+    public class ImportKeycloakRolesResponse
+    {
+        public required List<string> Created { get; init; }
+        public required List<string> Skipped { get; init; }
+        public required List<string> Stale { get; init; }
+    }
+}

--- a/PABC.Server/Keycloak/KeycloakAdminClient.cs
+++ b/PABC.Server/Keycloak/KeycloakAdminClient.cs
@@ -45,10 +45,15 @@ namespace PABC.Server.Keycloak
             using var response = await httpClient.GetAsync("roles?briefRepresentation=true", HttpCompletionOption.ResponseHeadersRead, token);
             response.EnsureSuccessStatusCode();
 
-            var roles = await response.Content.ReadFromJsonAsync<List<RoleRepresentation>>(cancellationToken: token)
-                ?? throw new InvalidOperationException("Ongeldig antwoord van Keycloak bij ophalen realm roles");
-
-            return roles;
+            try
+            {
+                return await response.Content.ReadFromJsonAsync<List<RoleRepresentation>>(cancellationToken: token)
+                    ?? throw new InvalidOperationException("Ongeldig antwoord van Keycloak bij ophalen realm roles");
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                throw new InvalidOperationException("Ongeldig antwoord van Keycloak bij ophalen realm roles", ex);
+            }
         }
     }
 

--- a/PABC.Server/Keycloak/KeycloakAdminClient.cs
+++ b/PABC.Server/Keycloak/KeycloakAdminClient.cs
@@ -9,6 +9,7 @@ namespace PABC.Server.Keycloak
     public interface IKeycloakAdminClient
     {
         IAsyncEnumerable<GroupRepresentation> GetGroups(string role, CancellationToken token);
+        Task<IReadOnlyList<RoleRepresentation>> GetRealmRoles(CancellationToken token);
     }
 
     public class KeycloakAdminClient(HttpClient httpClient, ILogger<KeycloakAdminClient> logger) : IKeycloakAdminClient
@@ -38,6 +39,17 @@ namespace PABC.Server.Keycloak
                 }
             }
         }
+
+        public async Task<IReadOnlyList<RoleRepresentation>> GetRealmRoles(CancellationToken token)
+        {
+            using var response = await httpClient.GetAsync("roles?briefRepresentation=true", HttpCompletionOption.ResponseHeadersRead, token);
+            response.EnsureSuccessStatusCode();
+
+            var roles = await response.Content.ReadFromJsonAsync<List<RoleRepresentation>>(cancellationToken: token)
+                ?? throw new InvalidOperationException("Ongeldig antwoord van Keycloak bij ophalen realm roles");
+
+            return roles;
+        }
     }
 
     public record GroupRepresentation
@@ -48,6 +60,11 @@ namespace PABC.Server.Keycloak
         public string? Description { get; init; }
         
         public required Dictionary<string, string[]> Attributes { get; init; }
+    };
+
+    public record RoleRepresentation
+    {
+        public required string Name { get; init; }
     };
 
     public static class KeycloakClientExtensions

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -3,6 +3,7 @@
 ## latest
 - Refactor query implementation for GetApplicationRolesPerEntityType to be more readable
 - [Zaaktypes uit Open Zaak importeren #148](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API/issues/148)
+- [Functionele rollen importeren vanuit Keycloak #147](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API/issues/147)
 
 ## v1.1.1
 

--- a/docs/manual/functionele-rollen-importeren.md
+++ b/docs/manual/functionele-rollen-importeren.md
@@ -1,0 +1,29 @@
+# Functionele rollen importeren
+
+## Vereisten
+
+De PABC moet gekoppeld zijn met Keycloak. Dit is standaard het geval wanneer de PABC correct is geïnstalleerd; er is geen extra configuratie nodig.
+
+## Hoe werkt het?
+
+Op de Beheer pagina verschijnt er een **Importeren** knop bij de Functionele rollen sectie.
+
+1. Klik op de **Importeren** knop.
+2. Er opent een dialoog met een toelichting. Klik op **Importeren** om de import te starten.
+3. De PABC haalt alle realm roles op uit het geconfigureerde Keycloak realm.
+4. Na afloop toont de dialoog het resultaat:
+   - **Aangemaakt**: functionele rollen die nieuw zijn aangemaakt in de PABC.
+   - **Overgeslagen**: functionele rollen die al bestonden in de PABC.
+   - **Niet meer in Keycloak**: functionele rollen die wel in de PABC staan maar niet meer in Keycloak voorkomen. Deze worden *niet* automatisch verwijderd.
+
+## Wat wordt er aangemaakt?
+
+Voor elke realm role in Keycloak die nog niet bestaat in de PABC wordt een nieuwe functionele rol aangemaakt. De naam van de functionele rol komt overeen met de naam van de Keycloak realm role.
+
+De match gebeurt op de exacte rolnaam (inclusief eventuele voor- en naloop spaties).
+
+## Belangrijke opmerkingen
+
+- Functionele rollen die al bestaan in de PABC worden niet gewijzigd of bijgewerkt.
+- Functionele rollen die niet meer in Keycloak voorkomen worden niet verwijderd uit de PABC.
+- De import kan meerdere keren uitgevoerd worden; bestaande rollen worden overgeslagen.

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -7,3 +7,4 @@ Handleiding
 
    API-toegang.md
    zaaktypes-importeren.md
+   functionele-rollen-importeren.md

--- a/pabc.client/src/components/item/ImportKeycloakRoles.vue
+++ b/pabc.client/src/components/item/ImportKeycloakRoles.vue
@@ -1,0 +1,112 @@
+<template>
+  <button type="button" class="button secondary" @click="openDialog">
+    Importeren <icon-container icon="import" />
+  </button>
+
+  <dialog ref="importDialog" @cancel.prevent="handleClose">
+    <button type="button" aria-label="Sluiten" class="dialog-close" @click="handleClose">
+      <icon-container icon="xmark" />
+    </button>
+
+    <template v-if="!result">
+      <h2>Functionele rollen importeren</h2>
+
+      <p>Importeer functionele rollen vanuit Keycloak.</p>
+
+      <p>Rollen die al bestaan in PABC worden overgeslagen.</p>
+
+      <small-spinner v-if="loading" />
+
+      <alert-inline v-if="error">{{ error }}</alert-inline>
+
+      <menu v-if="!loading" class="reset">
+        <li>
+          <button type="button" class="button" @click="handleImport">Importeren</button>
+        </li>
+
+        <li>
+          <button type="button" class="button secondary" @click="handleClose">Annuleren</button>
+        </li>
+      </menu>
+    </template>
+
+    <template v-else>
+      <h2>Import resultaat</h2>
+
+      <p>
+        <strong>{{ result.created.length }}</strong> functionele rol(len) aangemaakt.
+      </p>
+
+      <details v-if="result.created.length" open>
+        <summary>Aangemaakt ({{ result.created.length }})</summary>
+
+        <ul>
+          <li v-for="item in result.created" :key="item">{{ item }}</li>
+        </ul>
+      </details>
+
+      <details v-if="result.skipped.length">
+        <summary>Overgeslagen — bestonden al ({{ result.skipped.length }})</summary>
+
+        <ul>
+          <li v-for="item in result.skipped" :key="item">{{ item }}</li>
+        </ul>
+      </details>
+
+      <details v-if="result.stale.length">
+        <summary>Niet meer in Keycloak ({{ result.stale.length }})</summary>
+        <ul>
+          <li v-for="item in result.stale" :key="item">{{ item }}</li>
+        </ul>
+      </details>
+
+      <menu class="reset">
+        <li>
+          <button type="button" class="button" @click="handleClose">Sluiten</button>
+        </li>
+      </menu>
+    </template>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, useTemplateRef } from "vue";
+import SmallSpinner from "@/components/SmallSpinner.vue";
+import AlertInline from "@/components/AlertInline.vue";
+import IconContainer from "@/components/IconContainer.vue";
+import { importKeycloakRolesService, type ImportKeycloakRolesResponse } from "@/services/pabcService";
+
+const emit = defineEmits<{ (e: "refresh"): void }>();
+
+const loading = ref(false);
+const error = ref("");
+const result = ref<ImportKeycloakRolesResponse | null>(null);
+
+const importDialog = useTemplateRef("importDialog");
+
+const openDialog = () => {
+  result.value = null;
+  error.value = "";
+  importDialog.value?.showModal();
+};
+
+const handleImport = async () => {
+  loading.value = true;
+  error.value = "";
+
+  try {
+    result.value = await importKeycloakRolesService.import();
+    emit("refresh");
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Er is een fout opgetreden bij het importeren.";
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleClose = () => {
+  if (loading.value) return;
+
+  importDialog.value?.close();
+};
+</script>

--- a/pabc.client/src/services/pabcService.ts
+++ b/pabc.client/src/services/pabcService.ts
@@ -48,6 +48,12 @@ export type ImportZaaktypesResponse = {
   stale: string[];
 };
 
+export type ImportKeycloakRolesResponse = {
+  created: string[];
+  skipped: string[];
+  stale: string[];
+};
+
 const createPabcService = <T extends Item>(endpoint: string, createEmpty: () => T) => ({
   getAll: (): Promise<T[]> => get<T[]>(`/api/v1/${endpoint}`),
   getById: (id: string): Promise<T> => get<T>(`/api/v1/${endpoint}/${id}`),
@@ -110,4 +116,9 @@ export const importZaaktypesService = {
     get<{ enabled: boolean }>("/api/v1/entity-types/import-zaaktypes/enabled"),
   import: (): Promise<ImportZaaktypesResponse> =>
     post<ImportZaaktypesResponse>("/api/v1/entity-types/import-zaaktypes", undefined)
+};
+
+export const importKeycloakRolesService = {
+  import: (): Promise<ImportKeycloakRolesResponse> =>
+    post<ImportKeycloakRolesResponse>("/api/v1/functional-roles/import-keycloak", undefined)
 };

--- a/pabc.client/src/views/AdminView.vue
+++ b/pabc.client/src/views/AdminView.vue
@@ -63,6 +63,10 @@
       <template #form="{ form }">
         <functional-role-form :functional-role="form" />
       </template>
+
+      <template #actions="{ refresh }">
+        <import-keycloak-roles @refresh="refresh" />
+      </template>
     </item-details>
 
     <h2>Overige lijsten</h2>
@@ -119,6 +123,7 @@ import { useItemList } from "@/composables/use-item-list";
 import ItemDetails from "@/components/item/ItemDetails.vue";
 import DomainForm from "@/components/item/forms/DomainForm.vue";
 import FunctionalRoleForm from "@/components/item/forms/FunctionalRoleForm.vue";
+import ImportKeycloakRoles from "@/components/item/ImportKeycloakRoles.vue";
 import EntityTypeForm from "@/components/item/forms/EntityTypeForm.vue";
 import ApplicationRoleForm from "@/components/item/forms/ApplicationRoleForm.vue";
 import ApplicationForm from "@/components/item/forms/ApplicationForm.vue";


### PR DESCRIPTION
Closes #147

### Summary

Adds the ability to import functional roles from a configured Keycloak realm into the PABC. This avoids having to manually create functional roles that are already defined in Keycloak.

### What's included

**Backend**
- Extended `IKeycloakAdminClient` with `GetRealmRoles()` method to fetch realm roles from the Keycloak Admin REST API
- Added `RoleRepresentation` model
- New endpoint: `POST /api/v1/functional-roles/import-keycloak`
  - Creates a new functional role for each Keycloak realm role that doesn't already exist in the PABC
  - Exact match on role name (including leading/trailing spaces)
  - Returns `created`, `skipped` (already existed), and `stale` (exist in PABC but not in Keycloak) lists
  - Does **not** delete roles that no longer exist in Keycloak

**Frontend**
- New `ImportKeycloakRoles.vue` component with two-phase dialog (confirmation → result)
- Import button added to the "Functionele rollen" section on the admin page
- No feature toggle needed — Keycloak integration is mandatory

**Tests**
- 5 unit tests covering: new role creation, skip existing, detect stale, empty Keycloak response, error handling

**Documentation**
- User manual: `docs/manual/functionele-rollen-importeren.md`
- Changelog entry for #147

### Notes

- Uses the existing Keycloak Admin API client (with Duende client credentials), no additional configuration required